### PR TITLE
Select & Release bubble funcs -> no move root node

### DIFF
--- a/src/pages/MindMap/MindMapSimulation.tsx
+++ b/src/pages/MindMap/MindMapSimulation.tsx
@@ -102,12 +102,16 @@ const MindMapSimulationWithTransform = ({
 
   const releaseBubble = () => {
     if (nodeSelected) {
-      nodeSelected.x = nodeSelected?.fx ?? 0;
-      nodeSelected.y = nodeSelected?.fy ?? 0;
-      nodeSelected.fx = null;
-      nodeSelected.fy = null;
-      setNodeSelected(undefined);
-      simulation.alpha(1).restart();
+      if (nodeSelected.id!==0) {
+        setNodeSelected(undefined);
+      } else {
+        nodeSelected.x = nodeSelected?.fx ?? 0;
+        nodeSelected.y = nodeSelected?.fy ?? 0;
+        nodeSelected.fx = null;
+        nodeSelected.fy = null;
+        setNodeSelected(undefined);
+        simulation.alpha(1).restart();
+      }
     }
   };
 
@@ -131,7 +135,7 @@ const MindMapSimulationWithTransform = ({
           setNodeSelected(nodeClicked);
         }}
         onMouseMove={(e) => {
-          if (nodeSelected) {
+          if (nodeSelected && nodeSelected.id!==0) {
             nodeSelected.fx =
               (e.clientX - context.state.positionX + mouseDelta.x) /
               context.state.scale;


### PR DESCRIPTION
Still allows the root node to be selected and released, but prevents it from actually moving or restarting the simulation.

Fixes #21 