### PR TITLE
Disable root nodes dragging

### DIFF
--- a/src/pages/MindMap/MindMapSimulation.tsx
+++ b/src/pages/MindMap/MindMapSimulation.tsx
@@ -102,12 +102,16 @@ const MindMapSimulationWithTransform = ({
 
   const releaseBubble = () => {
     if (nodeSelected) {
-      nodeSelected.x = nodeSelected?.fx ?? 0;
-      nodeSelected.y = nodeSelected?.fy ?? 0;
-      nodeSelected.fx = null;
-      nodeSelected.fy = null;
-      setNodeSelected(undefined);
-      simulation.alpha(1).restart();
+      if (nodeSelected.id!==0) {
+        setNodeSelected(undefined);
+      } else {
+        nodeSelected.x = nodeSelected?.fx ?? 0;
+        nodeSelected.y = nodeSelected?.fy ?? 0;
+        nodeSelected.fx = null;
+        nodeSelected.fy = null;
+        setNodeSelected(undefined);
+        simulation.alpha(1).restart();
+      }
     }
   };
 
@@ -131,7 +135,7 @@ const MindMapSimulationWithTransform = ({
           setNodeSelected(nodeClicked);
         }}
         onMouseMove={(e) => {
-          if (nodeSelected) {
+          if (nodeSelected && nodeSelected.id!==0) {
             nodeSelected.fx =
               (e.clientX - context.state.positionX + mouseDelta.x) /
               context.state.scale;

--- a/src/pages/MindMap/MindMapSimulation.tsx
+++ b/src/pages/MindMap/MindMapSimulation.tsx
@@ -102,7 +102,7 @@ const MindMapSimulationWithTransform = ({
 
   const releaseBubble = () => {
     if (nodeSelected) {
-      if (nodeSelected.id!==0) {
+      if (nodeSelected.id===0) {
         setNodeSelected(undefined);
       } else {
         nodeSelected.x = nodeSelected?.fx ?? 0;

--- a/src/pages/MindMap/MindMapSimulation.tsx
+++ b/src/pages/MindMap/MindMapSimulation.tsx
@@ -102,7 +102,7 @@ const MindMapSimulationWithTransform = ({
 
   const releaseBubble = () => {
     if (nodeSelected) {
-      if (nodeSelected.id===0) {
+      if (nodeSelected.id === 0) {
         setNodeSelected(undefined);
       } else {
         nodeSelected.x = nodeSelected?.fx ?? 0;
@@ -135,7 +135,7 @@ const MindMapSimulationWithTransform = ({
           setNodeSelected(nodeClicked);
         }}
         onMouseMove={(e) => {
-          if (nodeSelected && nodeSelected.id!==0) {
+          if (nodeSelected && nodeSelected.id !== 0) {
             nodeSelected.fx =
               (e.clientX - context.state.positionX + mouseDelta.x) /
               context.state.scale;


### PR DESCRIPTION
Still allows the root node to be selected and released, but prevents it from actually moving or restarting the simulation.

Fixes #21 and resolves bug from #23 


